### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/iraj-bom/pom.xml
+++ b/iraj-bom/pom.xml
@@ -60,7 +60,7 @@
 		<version.commons-lang>3.3.1</version.commons-lang>
 		<version.commons-codec>1.9</version.commons-codec>
 		<version.commons-io>2.4</version.commons-io>
-		<version.commons-collections>3.2.1</version.commons-collections>
+		<version.commons-collections>3.2.2</version.commons-collections>
 		<version.commons-logging>1.1.3</version.commons-logging>
 		<version.jsoup>1.7.3</version.jsoup>
 		<version.tomcat-catalina>7.0.52</version.tomcat-catalina>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
